### PR TITLE
Added product type ID to cart metadata

### DIFF
--- a/src/SpeckCatalogCart/Model/CartProductMeta.php
+++ b/src/SpeckCatalogCart/Model/CartProductMeta.php
@@ -11,6 +11,7 @@ class CartProductMeta
     protected $flatOptions = array();
     protected $image;
     protected $uom;
+    protected $productTypeId;
 
     public function __construct(array $config = array())
     {
@@ -22,6 +23,7 @@ class CartProductMeta
            $this->flatOptions      = isset($config['flat_options'])       ? $config['flat_options']       : array();
            $this->image            = isset($config['image'])              ? $config['image']              : null;
            $this->uom              = isset($config['uom'])                ? $config['uom']                : null;
+            $this->productTypeId   = isset($config['product_type_id'])    ? $config['product_type_id']    : null;
         }
     }
 
@@ -99,6 +101,17 @@ class CartProductMeta
     public function setUom($uom)
     {
         $this->uom = $uom;
+        return $this;
+    }
+
+    public function getProductTypeId()
+    {
+        return $this->productTypeId;
+    }
+
+    public function setProductTypeId($productTypeId)
+    {
+        $this->productTypeId = $productTypeId;
         return $this;
     }
 }

--- a/src/SpeckCatalogCart/Service/CartService.php
+++ b/src/SpeckCatalogCart/Service/CartService.php
@@ -148,10 +148,16 @@ class CartService implements ServiceLocatorAwareInterface, EventManagerAwareInte
             'parent_option_name' => null,
             'product_id'         => $item->getProductId()
         );
+
         if ($item instanceOf Product && $parentOption) {
-                $meta['parent_option_id']   = $parentOption->getOptionId();
-                $meta['parent_option_name'] = $parentOption->__toString();
+            $meta['parent_option_id']   = $parentOption->getOptionId();
+            $meta['parent_option_name'] = $parentOption->__toString();
         }
+
+        if ($item instanceOf Product) {
+            $meta['product_type_id'] = $item->getProductTypeId();
+        }
+
         if ($item instanceOf Choice) {
             $meta['flat_options'] = $this->flatOptions;
         }


### PR DESCRIPTION
It seems like it would be useful to have the product type id in the metadata item for cart items. Based on the type of product in a basket will determine for me how the checkout process will operate so I need access to the product type id.
