### PR TITLE
Added a return to the addCartItem function to return the cartItem object...

### DIFF
--- a/src/SpeckCatalogCart/Service/CartService.php
+++ b/src/SpeckCatalogCart/Service/CartService.php
@@ -71,6 +71,8 @@ class CartService implements ServiceLocatorAwareInterface, EventManagerAwareInte
         $cartItem = $this->createCartItem($product, null, $uomString, $quantity);
 
         $this->addItemToCart($cartItem);
+
+        return $cartItem;
     }
 
     protected function addOptions($options = array(), $parentCartItem)


### PR DESCRIPTION
... that has been produced. Reason: I want access to the cart item id of the freshly created cart item and without this there is no way to obtain the id of the freshly created item.
